### PR TITLE
Update lib/wrench.js

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -74,7 +74,7 @@ exports.rmdirSyncRecursive = function(path, failSilent) {
 
     /*  Loop through and delete everything in the sub-tree after checking it */
     for(var i = 0; i < files.length; i++) {
-        var currFile = fs.statSync(path + "/" + files[i]);
+        var currFile = fs.lstatSync(path + "/" + files[i]);
 
         if(currFile.isDirectory()) // Recursive function back to the beginning
             exports.rmdirSyncRecursive(path + "/" + files[i]);


### PR DESCRIPTION
For rmdirSyncRecurisve I believe:
var currFile = fs.statSync(path + "/" + files[i]);
should be 
var currFile = fs.lstatSync(path + "/" + files[i]);

so any symbolic links will be evaluated as the link instead of the file it resolves to. 
Currently a symbolic linked folder being deleted will receive an ENOTDIR, not a directory. 
