### PR TITLE
Replaced a few more statSync references with lstatSync to ensure symboli...

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -114,13 +114,10 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation) {
     var files = fs.readdirSync(sourceDir);
 
     for(var i = 0; i < files.length; i++) {
-        var currFile = fs.statSync(sourceDir + "/" + files[i]);
+        var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
 
         if(currFile.isDirectory()) {
-            /*  Create a new directory in our copied version... */
-            fs.mkdirSync(newDirLocation + "/" + files[i], currFile.mode);
-
-            /*  ...and then recursion this thing right on back. */
+            /*  recursion this thing right on back. */
             exports.copyDirSyncRecursive(sourceDir + "/" + files[i], newDirLocation + "/" + files[i]);
         } else if(currFile.isSymbolicLink()) {
             var symlinkFull = fs.readlinkSync(sourceDir + "/" + files[i]);
@@ -144,7 +141,7 @@ exports.chmodSyncRecursive = function(sourceDir, filemode) {
     var files = fs.readdirSync(sourceDir);
 
     for(var i = 0; i < files.length; i++) {
-        var currFile = fs.statSync(sourceDir + "/" + files[i]);
+        var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
 
         if(currFile.isDirectory()) {
             /*  ...and recursion this thing right on back. */
@@ -171,7 +168,7 @@ exports.chownSyncRecursive = function(sourceDir, uid, gid) {
     var files = fs.readdirSync(sourceDir);
 
     for(var i = 0; i < files.length; i++) {
-        var currFile = fs.statSync(sourceDir + "/" + files[i]);
+        var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
 
         if(currFile.isDirectory()) {
             /*  ...and recursion this thing right on back. */


### PR DESCRIPTION
...c links to directories aren't detected as directories which causes errors. Also in copyDirSyncRecursive removed an explict call to mkDirSync before recusively calling to copy the sub directory as the recursive method is already creating that directory. The explicit call to create the sub directory beforehand is causing the directory to be created twice causing an error.
