### PR TITLE
LineReader.hasNextLine will go to an endless loop

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -368,9 +368,12 @@ exports.LineReader.prototype = {
         var res = fs.readSync(this.fd, this.bufferSize, position, "ascii");
 
         this.buffer += res[0];
-        if(res[1] === 0) return -1;
+        if(res[1] === 0) {
+            this.currentPosition = -1;
+        } else {
+            this.currentPosition = position + res[1];
+        }
 
-        this.currentPosition = position + res[1];
         return this.currentPosition;
     },
 
@@ -378,7 +381,6 @@ exports.LineReader.prototype = {
         while(this.buffer.indexOf('\n') === -1) {
             this.getBufferAndSetCurrentPosition(this.currentPosition);
             if(this.currentPosition === -1) return false;
-            if(this.buffer.length === 0) return false;
         }
 
         if(this.buffer.indexOf("\n") > -1) return true;


### PR DESCRIPTION
LineReader.hasNextLine will go to an endless loop when buffer is empty or file not end with \n
