### PR TITLE
Filter options for copyDirSyncRecursive

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -183,6 +183,11 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
     var files = fs.readdirSync(sourceDir);
 
     for(var i = 0; i < files.length; i++) {
+        // ignores all files or directories which match the RegExp in opts.filter
+		if(!opts.whitelist && opts.filter && files[i].match(opts.filter)) continue;
+		// if opts.whitelist is true every file or directory which doesn't match opts.filter will be ignored
+		if(opts.whitelist && opts.filter && !files[i].match(opts.filter)) continue;
+        
         var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
 
         if(currFile.isDirectory()) {


### PR DESCRIPTION
-- opts.filter (RegExp): a RegExp which could look like this: /^CVS$|.idea$|.DS_Store$/. If added, every file or directory which matches the RegExp will be ignored. In this example every "CVS" directory and all ".idea" and ".DS_Stores" files would be ignored.
-- opts.filter (Boolean): If set tu true, the RegExp in opts.filter will be used as a whitelist. Every file or directory which DOESN'T match opts.filter will be ignored.
