### PR TITLE
Null check in copyDirSyncRecursive

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -164,7 +164,6 @@ exports.rmdirSyncRecursive = function(path, failSilent) {
  *  Note: Directories should be passed to this function without a trailing slash.
  */
 exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
-
     if (!opts || !opts.preserve) {
         try {
             if(fs.statSync(newDirLocation).isDirectory()) exports.rmdirSyncRecursive(newDirLocation);
@@ -194,7 +193,7 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
         var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
 
         var fCopyFile = function(srcFile, destFile) {
-            if (opts.preserveFiles && fs.existsSync(destFile)) return;
+            if (typeof opts !== 'undefined' && opts.preserveFiles && fs.existsSync(destFile)) return;
 
             var contents = fs.readFileSync(srcFile);
             fs.writeFileSync(destFile, contents);

--- a/tests/copydirsync_unix.js
+++ b/tests/copydirsync_unix.js
@@ -77,6 +77,15 @@ function checkResultOverwriteFiles(test, files) {
 }
 
 module.exports = testCase({
+    test_copyDirSyncRecursiveWithoutOptions: function(test) {
+        var dir = path.join(__dirname, 'shown');
+        var testdir = path.join(__dirname, 'testdir');
+
+        wrench.copyDirSyncRecursive(dir, testdir);
+
+        wrench.rmdirSyncRecursive(testdir);
+        test.done();
+    },
     test_copyDirSyncRecursiveHidden: function(test) {
         var dir = path.join(__dirname, 'shown');
         var testdir = path.join(__dirname, 'testdir');


### PR DESCRIPTION
copyDirSyncRecursive breaks when opts are not passed in. Added test and null check to fix this.
