### PR TITLE
Update lib/wrench.js

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -205,7 +205,7 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
         } else if(currFile.isSymbolicLink()) {
             var symlinkFull = fs.readlinkSync(sourceDir + "/" + files[i]);
 
-            if (!opts.inflateSymlinks) {
+            if (opts !== undefined && opts.inflateSymlinks === false) {
                 fs.symlinkSync(symlinkFull, newDirLocation + "/" + files[i]);
                 continue;
             }


### PR DESCRIPTION
Code crashes on this line if opts is undefined. I'm guessing that 
the default behavior should be that symlinked files gets copied as
new files unless the option inflateSymlinks is set to false.
