### PR TITLE
copyDirRecursive callback receives at least a null error parameter. 

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -329,7 +329,7 @@ exports.copyDirRecursive = function copyDirRecursive(srcDir, newDir, clbk) {
 
                         var filename = files.shift();
                         if (filename === null || typeof filename == 'undefined')
-                            return clbk();
+                            return clbk(null);
 
                         var file = srcDir+'/'+filename,
                             newFile = newDir+'/'+filename;


### PR DESCRIPTION
Issue #47.
