### PR TITLE
Typeof typo causes error running wrench.js 

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -293,7 +293,7 @@ exports.rmdirRecursive = function rmdirRecursive(dir, failSilent, clbk){
         if(err && typeof failSilent === 'boolean' && !failSilent) 
 		return clbk(err);
 
-	if(typof failSilent === 'function')
+	if(typeof failSilent === 'function')
 		clbk = failSilent;
 
         (function rmFile(err){


### PR DESCRIPTION
Using meteor-mocha-web repository that uses wrench.js.  Got "Unexpected Identifier" line 296 when trying to run "mrt add mocha-web" 
