### PR TITLE
Fixed copyDirRecursive when forceDeleting old files

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -323,11 +323,12 @@ exports.rmdirRecursive = function rmdirRecursive(dir, failSilent, clbk){
  *  Note: Directories should be passed to this function without a trailing slash.
  */
 exports.copyDirRecursive = function copyDirRecursive(srcDir, newDir, opts, clbk) {
+    var copyDirArguments = arguments;
     fs.stat(newDir, function(err, newDirStat){
         if(!err) {
 		if(typeof opts !== 'undefined' && typeof opts !== 'function' && opts.forceDelete)
 			return exports.rmdirRecursive(newDir, function(err){
-				copyDirRecursive.apply(this, arguments);
+				copyDirRecursive.apply(this, copyDirArguments);
         		});
 		else
 			return clbk(new Error('You are trying to delete a directory that already exists. Specify forceDelete in an options object to override this.'));


### PR DESCRIPTION
I think the problem is with function scoping and arguments. The applied call to copyDirRecursive doesn't have the right arguments.

NOTE: I'm pretty new to node and some of the test suite is failing on my machine, so it's possible it's an issue with my setup (Mountain Lion with node via homebrew).
