### PR TITLE
fixed getNextLine

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -434,7 +434,7 @@ exports.LineReader.prototype = {
 
     getNextLine: function() {
         var lineEnd = this.buffer.indexOf("\n"),
-            result = this.buffer.substring(0, lineEnd ? lineEnd : this.buffer.length);
+            result = this.buffer.substring(0, lineEnd != -1 ? lineEnd : this.buffer.length);
 
         this.buffer = this.buffer.substring(result.length + 1, this.buffer.length);
         return result;


### PR DESCRIPTION
Fixed getNextLine. Previously, a line break at position 0 would cause the whole buffer to be returned.
