### PR TITLE
Update wrench.js

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -323,11 +323,12 @@ exports.rmdirRecursive = function rmdirRecursive(dir, failSilent, clbk){
  *  Note: Directories should be passed to this function without a trailing slash.
  */
 exports.copyDirRecursive = function copyDirRecursive(srcDir, newDir, opts, clbk) {
+    var originalArguments = Array.prototype.slice.apply(arguments);
     fs.stat(newDir, function(err, newDirStat){
         if(!err) {
 		if(typeof opts !== 'undefined' && typeof opts !== 'function' && opts.forceDelete)
 			return exports.rmdirRecursive(newDir, function(err){
-				copyDirRecursive.apply(this, arguments);
+				copyDirRecursive.apply(this, originalArguments);
         		});
 		else
 			return clbk(new Error('You are trying to delete a directory that already exists. Specify forceDelete in an options object to override this.'));


### PR DESCRIPTION
Fixes a bug (not sure if has been reported).

`copyDirRecursive` calls itself from the `rmdirRecursive` callback when newDir exists. It should call itself with the original copyDirRecursive arguments, not the callback arguments. 

Also `fun.apply(thisArg, argsArray)` expects argsArray to be an array (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)) but `arguments` is not an array (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/arguments))

Very similar to [pull request 56](https://github.com/ryanmcgrath/wrench-js/pull/56) (I wrote my code before I noticed danielholmes did a similar fix).
