### PR TITLE
copyDirSyncRecursive: Remove obsolete typeof check

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -219,7 +219,7 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
 
     try {
         if(fs.statSync(newDirLocation).isDirectory()) { 
-            if(typeof opts !== 'undefined' && opts.forceDelete) {
+            if(opts.forceDelete) {
             exports.rmdirSyncRecursive(newDirLocation);
             } else {
                 return new Error('You are trying to delete a directory that already exists. Specify forceDelete in the opts argument to override this. Bailing~');


### PR DESCRIPTION
Variable `opts` is never undefined at this point because of `opts = opts || {};`.
