### PR TITLE
Updating wrench rmdirSyncRecursive to support permissions issues for win...

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -12,7 +12,8 @@
  */
 
 var fs = require("fs"),
-    _path = require("path");
+    _path = require("path"),
+    isWindows = !!process.platform.match(/^win/);
 
 /*  wrench.readdirSyncRecursive("directory_path");
  *
@@ -122,7 +123,7 @@ exports.readdirRecursive = function(baseDir, fn) {
 
 
 
-/*  wrench.rmdirSyncRecursive("directory_path", forceDelete, failSilent);
+/*  wrench.rmdirSyncRecursive("directory_path", failSilent);
  *
  *  Recursively dives through directories and obliterates everything about it. This is a
  *  Sync-function, which blocks things until it's done. No idea why anybody would want an
@@ -140,16 +141,27 @@ exports.rmdirSyncRecursive = function(path, failSilent) {
 
     /*  Loop through and delete everything in the sub-tree after checking it */
     for(var i = 0; i < files.length; i++) {
-        var currFile = fs.lstatSync(_path.join(path, files[i]));
+        var file = _path.join(path, files[i]);
+        var currFile = fs.lstatSync(file);
 
-        if(currFile.isDirectory()) // Recursive function back to the beginning
-            exports.rmdirSyncRecursive(_path.join(path, files[i]));
+        if(currFile.isDirectory())  {
+            // Recursive function back to the beginning
+            exports.rmdirSyncRecursive(file);
+        } else if(currFile.isSymbolicLink()) {
+            // Unlink symlinks
+            if (isWindows) {
+                fs.chmodSync(file, 666) // Windows needs this unless joyent/node#3006 is resolved..
+            }
 
-        else if(currFile.isSymbolicLink()) // Unlink symlinks
-            fs.unlinkSync(_path.join(path, files[i]));
+            fs.unlinkSync(file);
+        } else {
+            // Assume it's a file - perhaps a try/catch belongs here?
+            if (isWindows) {
+                fs.chmodSync(file, 666) // Windows needs this unless joyent/node#3006 is resolved..
+            }
 
-        else // Assume it's a file - perhaps a try/catch belongs here?
-            fs.unlinkSync(_path.join(path, files[i]));
+            fs.unlinkSync(file);
+        }
     }
 
     /*  Now that we know everything in the sub-tree has been deleted, we can delete the main

--- a/tests/rmdirSyncRecursive.js
+++ b/tests/rmdirSyncRecursive.js
@@ -1,0 +1,22 @@
+var testCase = require('nodeunit').testCase;
+var fs = require('fs');
+var wrench = require('../lib/wrench');
+var path = require('path');
+
+module.exports = testCase({
+    test_rmdirSyncRecursive: function(test) {
+        var dir = __dirname + '/_tmp/foo/bar';
+
+        wrench.mkdirSyncRecursive(dir, 0777);
+
+        test.equals(fs.existsSync(dir), true, 'Dir should exist - mkdirSyncRecursive not working?');
+
+        wrench.rmdirSyncRecursive(dir);
+
+        test.equals(fs.existsSync(dir), false, 'Dir should not exist now...');
+
+        test.done();
+    },
+});
+
+// vim: et ts=4 sw=4

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -4,5 +4,6 @@
 module.exports = {
     group_mkdir: require('./mkdir'),
     group_readdir: require('./readdir'),
-    group_copydir: require('./copydirsync_unix')
+    group_copydir: require('./copydirsync_unix'),
+    group_rmdir: require('./rmdirSyncRecursive')
 };


### PR DESCRIPTION
Updating wrench rmdirSyncRecursive to support permissions issues for Windows. We now set read/write permissions to all before we try to remove the file. This is a quirk of Windows file systems. Also added a simple test for rmdirSyncRecursive.
