### PR TITLE
Fix inflateSymlinks flag errors for absolute symlinks

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -281,18 +281,19 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
             exports.copyDirSyncRecursive(_path.join(sourceDir, files[i]), _path.join(newDirLocation, files[i]), opts);
         } else if(currFile.isSymbolicLink()) {
             var symlinkFull = fs.readlinkSync(_path.join(sourceDir, files[i]));
+            symlinkFull = _path.resolve(fs.realpathSync(sourceDir), symlinkFull);
 
             if (typeof opts !== 'undefined' && !opts.inflateSymlinks) {
                 fs.symlinkSync(symlinkFull, _path.join(newDirLocation, files[i]));
                 continue;
             }
 
-            var tmpCurrFile = fs.lstatSync(_path.join(sourceDir, symlinkFull));
+            var tmpCurrFile = fs.lstatSync(symlinkFull);
             if (tmpCurrFile.isDirectory()) {
-                exports.copyDirSyncRecursive(_path.join(sourceDir, symlinkFull), _path.join(newDirLocation, files[i]), opts);
+                exports.copyDirSyncRecursive(symlinkFull, _path.join(newDirLocation, files[i]), opts);
             } else {
                 /*  At this point, we've hit a file actually worth copying... so copy it on over. */
-                fCopyFile(_path.join(sourceDir, symlinkFull), _path.join(newDirLocation, files[i]));
+                fCopyFile(symlinkFull, _path.join(newDirLocation, files[i]));
             }
         } else {
             /*  At this point, we've hit a file actually worth copying... so copy it on over. */

--- a/tests/copydirsync_unix.js
+++ b/tests/copydirsync_unix.js
@@ -46,6 +46,21 @@ function checkResultInflate(test, files) {
     test.deepEqual(fs.lstatSync(path.join(__dirname, 'testdir/bar.txt')).isSymbolicLink(), false);
 }
 
+function checkResultInflateAbsolute(test, files) {
+    var check = [
+        '.hidden',
+        'absolute-bar.txt',
+        'bar.txt',
+        'test',
+        path.join('.hidden', 'dolor.md')
+    ];
+
+    test.deepEqual(files, check);
+
+    test.deepEqual(fs.lstatSync(path.join(__dirname, 'testdir/.hidden')).isSymbolicLink(), false);
+    test.deepEqual(fs.lstatSync(path.join(__dirname, 'testdir/bar.txt')).isSymbolicLink(), false);
+}
+
 function checkResultDontInflate(test, files) {
     var check = [
         '.hidden',
@@ -134,6 +149,27 @@ module.exports = testCase({
         checkResultInflate(test, files);
 
         wrench.rmdirSyncRecursive(testdir);
+
+        test.done();
+    },
+    test_copyDirSyncRecursiveInflateAbsoluteSymlinks: function(test) {
+        var dir = path.join(__dirname, 'withsymlinks');
+        var testdir = path.join(__dirname, 'testdir');
+
+        fs.symlinkSync(
+            path.resolve(__dirname, 'shown/bar.txt'),
+            path.join(dir, 'absolute-bar.txt')
+        );
+
+        wrench.mkdirSyncRecursive(testdir, 0777);
+        wrench.copyDirSyncRecursive(dir, testdir, { forceDelete: true, excludeHiddenUnix: false, inflateSymlinks: true });
+
+        var files = wrench.readdirSyncRecursive(testdir);
+
+        checkResultInflateAbsolute(test, files);
+
+        wrench.rmdirSyncRecursive(testdir);
+        fs.unlinkSync(path.join(dir, 'absolute-bar.txt'));
 
         test.done();
     },


### PR DESCRIPTION
The `inflateSymlinks: true` for `copyDirSyncRecursive` assumes symlinks will have relatives paths. A symlink with an absolute path throws an error since the path cannot be correctly resolved.

This pull request fixes those errors and adds tests.
