### PR TITLE
Set isDir to false for non-existant directory

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -28,7 +28,7 @@ exports.readdirSyncRecursive = function(baseDir) {
             curFiles,
             nextDirs,
             isDir = function(fname){
-                return fs.statSync( _path.join(baseDir, fname) ).isDirectory();
+                return fs.existsSync(_path.join(baseDir, fname)) ? fs.statSync( _path.join(baseDir, fname) ).isDirectory() : false;
             },
             prependBaseDir = function(fname){
                 return _path.join(baseDir, fname);


### PR DESCRIPTION
The PR for issue #45 resolves problems for `readdirRecursive`, but not for `readdirRecursiveSync`. This patch sets `isDir = false` when a directory cannot be found, effectively ceasing further processing.
