### PR TITLE
Remove redundant check

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -231,9 +231,9 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
     opts = opts || {};
 
     try {
-        if(fs.statSync(newDirLocation).isDirectory()) { 
+        if(fs.statSync(newDirLocation).isDirectory()) {
             if(opts.forceDelete) {
-            exports.rmdirSyncRecursive(newDirLocation);
+                exports.rmdirSyncRecursive(newDirLocation);
             } else {
                 return new Error('You are trying to delete a directory that already exists. Specify forceDelete in the opts argument to override this. Bailing~');
             }
@@ -256,15 +256,9 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
 
     for(var i = 0; i < files.length; i++) {
         // ignores all files or directories which match the RegExp in opts.filter
-        if(typeof opts !== 'undefined') {
-            if (hasFilter) {
-                if (!isFileIncluded(opts, sourceDir, files[i])) {
-                    continue;
-                }
-            }
-            
-            if (opts.excludeHiddenUnix && /^\./.test(files[i])) continue;
-        }
+        if (hasFilter && !isFileIncluded(opts, sourceDir, files[i])) continue;
+
+        if (opts.excludeHiddenUnix && /^\./.test(files[i])) continue;
 
         var currFile = fs.lstatSync(_path.join(sourceDir, files[i]));
 


### PR DESCRIPTION
We default opts to {} at the top of the function.

Also fix indentation.
