### PR TITLE
readdirSyncRecursive: add a filter argument

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -15,12 +15,21 @@ var fs = require("fs"),
     _path = require("path"),
     isWindows = !!process.platform.match(/^win/);
 
-/*  wrench.readdirSyncRecursive("directory_path");
+/*  wrench.readdirSyncRecursive("directory_path", filter);
  *
  *  Recursively dives through directories and read the contents of all the
  *  children directories.
+ *
+ *  filter is an optional filter function that will be applied on the records of
+ *  each sub-directory to keep only the records you need. Avoiding redundencies
+ *  is critical for big folders trees.
+ *
+ *  Example:
+ *
+ *      var txt_files = wrench.readdirSyncRecursive(dir, function (x) {return /\.txt$/.test(x);});
+ *
  */
-exports.readdirSyncRecursive = function(baseDir) {
+exports.readdirSyncRecursive = function(baseDir, filter) {
     baseDir = baseDir.replace(/\/$/, '');
 
     var readdirSyncRecursive = function(baseDir) {
@@ -36,6 +45,12 @@ exports.readdirSyncRecursive = function(baseDir) {
 
         curFiles = fs.readdirSync(baseDir);
         nextDirs = curFiles.filter(isDir);
+
+        // filter results
+        if (typeof filter === 'function') {
+            curFiles = curFiles.filter(filter)
+        }
+
         curFiles = curFiles.map(prependBaseDir);
 
         files = files.concat( curFiles );

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,9 @@ wrench.rmdirSyncRecursive('my_directory_name', failSilently);
 // Recursively read directories contents.
 wrench.readdirSyncRecursive('my_directory_name');
 
+// Recursively read directories contents, filter results (efficient memory usage for big folders trees).
+wrench.readdirSyncRecursive('my_directory_name', function (x) { return /\.txt$/.test(x); });
+
 // Recursively chmod the entire sub-tree of a directory
 wrench.chmodSyncRecursive('my_directory_name', 0755);
 

--- a/tests/readdir.js
+++ b/tests/readdir.js
@@ -30,6 +30,16 @@ module.exports = testCase({
         checkResult(test, files);
     },
 
+    test_readdirSyncRecursive_filter: function(test) {
+        var dir = path.join(__dirname, 'readdir');
+
+        var txt_files = wrench.readdirSyncRecursive(dir, function (x) {return /\.txt$/.test(x);});
+
+        test.deepEqual(txt_files, ['bar.txt', path.join('foo', 'lorem.txt')]);
+
+        test.done();
+    },
+
     test_readdirRecursive: function(test) {
         var dir = path.join(__dirname, 'readdir');
 


### PR DESCRIPTION
filter is an optional filter function that will be applied on the records of
each sub-directory to keep only the records you need. Avoiding redundencies
is critical for big folders trees
