### PR TITLE
readdirSyncRecursive: follow symlinks only if we haven't read the destination yet

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -23,7 +23,14 @@ var fs = require("fs"),
 exports.readdirSyncRecursive = function(baseDir) {
     baseDir = baseDir.replace(/\/$/, '');
 
+    var checkedInodes = {};
     var readdirSyncRecursive = function(baseDir) {
+        var inode = fs.statSync(baseDir).ino;
+        if (inode in checkedInodes) {
+            return [];
+        }
+        checkedInodes[inode] = true;
+
         var files = [],
             curFiles,
             nextDirs,


### PR DESCRIPTION
Fix an issue whre readdirSyncRecursive will get into infinite loop for
circular symlinks.

Note: fix to readdirRecursive is also needed.
