### PR TITLE
Updated recursive copy logic to honor the preserveFiles option

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -233,9 +233,9 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
     try {
         if(fs.statSync(newDirLocation).isDirectory()) { 
             if(opts.forceDelete) {
-            exports.rmdirSyncRecursive(newDirLocation);
-            } else {
-                return new Error('You are trying to delete a directory that already exists. Specify forceDelete in the opts argument to override this. Bailing~');
+                exports.rmdirSyncRecursive(newDirLocation);
+            } else if(!opts.preserveFiles) {
+                return new Error('You are trying to copy a directory onto a directory that already exists. Specify forceDelete or preserveFiles in the opts argument to specify desired behavior');
             }
         }
     } catch(e) { }
@@ -413,8 +413,9 @@ exports.copyDirRecursive = function copyDirRecursive(srcDir, newDir, opts, clbk)
                 return exports.rmdirRecursive(newDir, function(err) {
                     copyDirRecursive.apply(this, originalArguments);
                 });
-            else
-                return clbk(new Error('You are trying to delete a directory that already exists. Specify forceDelete in an options object to override this.'));
+            else if(typeof opts !== 'undefined' && typeof opts !== 'function' && !opts.preserveFiles) {
+              return clbk(new Error('You are trying to copy a directory onto a directory that already exists. Specify forceDelete or preserveFiles in the opts argument to specify desired behavior'));
+            }
         }
 
 	if(typeof opts === 'function')


### PR DESCRIPTION
I feel that when the option `preserveFiles: true` and `forceDelete: false` is specified, an Error() shouldn't be returned. 

The existing test case `test_copyDirSyncRecursivePreserveFiles` was only working because it was failing silently and no copy was taking place.
