### PR TITLE
copyDirSyncRecursive: Preserve timestamps for copied directories.

### DIFF
--- a/lib/wrench.js
+++ b/lib/wrench.js
@@ -304,6 +304,10 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
             fCopyFile(_path.join(sourceDir, files[i]), _path.join(newDirLocation, files[i]));
         }
     }
+    
+    if (preserveTimestamps === true) {
+        fs.utimesSync(newDirLocation, checkDir.atime, checkDir.mtime);
+    }
 };
 
 /*  wrench.chmodSyncRecursive("directory", filemode);


### PR DESCRIPTION
copyDirSyncRecursive does not preserve timestamps for directory. This pull request honors the option.