### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
   
   "scripts": { "test": "nodeunit tests/runner.js" },
 
-  "licenses": [{
-    "type" : "MIT",
-    "url" : "http://github.com/ryanmcgrath/wrench-js/raw/master/LICENSE"
-  }]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/